### PR TITLE
update module source to terraform registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ data "aws_caller_identity" "this" {}
 data "aws_organizations_organization" "this" {}
 
 module "organization_iam_role" {
-  source = "github.com/unicrons/terraform-aws-organization-iam-role"
+  source = "unicrons/organization-iam-role/aws"
 
   stack_set_name        = "example"
   stack_set_description = "example"


### PR DESCRIPTION
After publishing the module on the Terraform registry, we can use the registry as a source